### PR TITLE
chore(npm): init npm, gulp, semantic-release and commitizen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '4'
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,0 +1,25 @@
+var del = require('del');
+var gulp = require('gulp');
+var mocha = require('gulp-mocha');
+var runSequence = require('run-sequence');
+
+gulp.task('default',function(){
+  console.log('This is the default task');
+})
+
+gulp.task('delete',function(callback){
+   del('dist/**/*', callback());
+})
+gulp.task('test',function(){
+  return gulp.src('src/**/*.spec.js', {read: false})
+    .pipe(mocha());
+})
+
+gulp.task('build',function(callback){
+  runSequence('test','delete','copy',callback);
+})
+
+gulp.task('copy',function(){
+  return gulp.src(['src/**/*.js','!src/**/*.spec.js'])
+    .pipe(gulp.dest('dist'));
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "gulp-talk2me",
+  "description": "A little package to generate help texts for gulp tasks",
+  "main": "dist/app.js",
+  "scripts": {
+    "test": "gulp test",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/belgac/gulp-talk2me.git"
+  },
+  "author": "Hans Scheuren <hans.scheuren@bizliner.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/belgac/gulp-talk2me/issues"
+  },
+  "homepage": "https://github.com/belgac/gulp-talk2me#readme",
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "commitizen": "^2.4.3",
+    "cz-conventional-changelog": "^1.1.4",
+    "del": "^2.0.2",
+    "gulp": "^3.9.0",
+    "gulp-mocha": "^2.1.3",
+    "mocha": "^2.3.3",
+    "run-sequence": "^1.1.4",
+    "semantic-release": "^4.3.5",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
+}


### PR DESCRIPTION
init the package.json and travis yml files with basic module info, gulp depndencies, build and test
tasks, commitizen, mocha, chai and semantic-release to enforce angular commit message conventions, automatic changelog generation, tests and npm registry publication
