### PR TITLE
fix(npm): add gulp to dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/app.js",
   "scripts": {
     "test": "gulp test",
-    "postinstall" : "gulp build",
+    "postinstall": "gulp build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -34,5 +34,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "dependencies": {
+    "gulp": "^3.9.0"
   }
 }


### PR DESCRIPTION
add gulp to the non dev dependecies as it is used in the post install script

Closes #11
