### PR TITLE
chore(npm): uninstall unneeded dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,8 @@
     "chai": "^3.4.1",
     "commitizen": "^2.4.3",
     "cz-conventional-changelog": "^1.1.4",
-    "del": "^2.0.2",
-    "gulp": "^3.9.0",
-    "gulp-mocha": "^2.1.3",
     "mocha": "^2.3.3",
-    "run-sequence": "^1.1.4",
-    "semantic-release": "^4.3.5",
-    "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "semantic-release": "^4.3.5"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
The following dev dependencies are already in dependencies and are now uninstalled: del, gulp,
gulp-mocha and run-sequence. The following dev dependencies aren't used in the projetc and are now
uninstalled: sinon and sinon-chai
